### PR TITLE
Remove deprecated environment variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,9 +35,10 @@ minio_server_env_extra: |
 # Additional MinIO server CLI options
 minio_server_opts: ""
 
-# MinIO access and secret keys
-minio_access_key: "minio"
-minio_secret_key: "minio123"
+# MinIO root username password
+# Reading existing values from deprecated access and secret key varibles
+minio_root_username: "{{ minio_access_key | default('minio') }}"
+minio_root_password: "{{ minio_secret_key | default('minio123') }}"
 
 # Switches to enable/disable the MinIO server and/or MinIO client installation.
 minio_install_server: true

--- a/templates/minio.env.j2
+++ b/templates/minio.env.j2
@@ -7,13 +7,13 @@ MINIO_ARGS="{{ minio_server_args | join(' ') }}"
 # MinIO cli options.
 MINIO_OPTS="--address {{ minio_server_addr }} {{ minio_server_opts }}"
 
-{% if minio_access_key %}
-# Access Key of the server.
-MINIO_ACCESS_KEY="{{ minio_access_key }}"
+{% if minio_root_username %}
+# Root username for the server.
+MINIO_ROOT_USER="{{ minio_root_username }}"
 {% endif %}
-{% if minio_secret_key %}
-# Secret key of the server.
-MINIO_SECRET_KEY="{{ minio_secret_key }}"
+{% if minio_root_password %}
+# Root password for the server.
+MINIO_ROOT_PASSWORD="{{ minio_root_password }}"
 {% endif %}
 
 {{ minio_server_env_extra }}


### PR DESCRIPTION
Updated default variables and environment settings file to conform with deprecated access and secret key settings.

Should have created draft PR #3, sorry.

Previous PR had misspelled `MINIO_ROOT_USER` (was `_USERNAME`). Also updated `if` statements for new variable names.

Successfully tested in own environment.