### PR TITLE
make server config more customizable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,8 +16,11 @@ minio_group: minio
 # Path to the file containing the ENV variables for the MinIO server
 minio_server_envfile: /etc/default/minio
 
+# Minio server ip/fqdn and port. This makes up the server_addr below
+minio_server_ip: ""
+minio_server_port: "9091"
 # MinIO server listen address
-minio_server_addr: ":9091"
+minio_server_addr: "{{ minio_server_ip }}:{{ minio_server_port}}"
 
 # MinIO server data directories
 minio_server_datadirs:


### PR DESCRIPTION
By splitting the variable "minio_server_addr" into two variables we are more flexible.