### PR TITLE
removed checksum lookup tasks because get_url can do this

### DIFF
--- a/tasks/install-client.yml
+++ b/tasks/install-client.yml
@@ -14,10 +14,6 @@
     _minio_client_download_url: "{{ _minio_client_download_base_url }}/archive/mc.{{ minio_client_release }}"
   when: minio_client_release | length > 0
 
-- name: "Get the MinIO client checksum for {{ go_arch }} architecture"
-  set_fact:
-    _minio_client_checksum: "{{ lookup('url', _minio_client_download_url + '.sha256sum').split(' ')[0] }}"
-
 - name: Download the MinIO client
   get_url:
     url: "{{ _minio_client_download_url }}"
@@ -25,7 +21,7 @@
     owner: "root"
     group: "root"
     mode: 0755
-    checksum: "sha256:{{ _minio_client_checksum }}"
+    checksum: "sha256:{{ _minio_client_download_url }}.sha256sum"
   register: _download_client
   until: _download_client is succeeded
   retries: 5

--- a/tasks/install-server.yml
+++ b/tasks/install-server.yml
@@ -13,10 +13,6 @@
     _minio_server_download_url: "{{ _minio_server_download_base_url }}/archive/minio.{{ minio_server_release }}"
   when: minio_server_release | length > 0
 
-- name: "Get the MinIO server checksum for {{ go_arch }} architecture"
-  set_fact:
-    _minio_server_checksum: "{{ lookup('url', _minio_server_download_url + '.sha256sum').split(' ')[0] }}"
-
 - name: Create MinIO group
   group:
     name: "{{ minio_group }}"
@@ -46,7 +42,7 @@
     owner: "root"
     group: "root"
     mode: 0755
-    checksum: "sha256:{{ _minio_server_checksum }}"
+    checksum: "sha256:{{ _minio_server_download_url }}.sha256sum"
   register: _download_server
   until: _download_server is succeeded
   retries: 5


### PR DESCRIPTION
The checksum tasks are not necessary, the get_url module can do that [out-of-the-box](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html#parameter-checksum).
My problem was that the lookup module did not take the environment variables for the proxy. The get_url module did that perfectly.