### PR TITLE
added console addr support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,11 @@ minio_server_envfile: /etc/default/minio
 # MinIO server listen address
 minio_server_addr: ":9091"
 
+# MinIO console addr:
+minio_console_ip: ""
+minio_console_port: ""
+minio_console_addr: "{{ minio_console_ip }}:{{ minio_console_port }}"
+
 # MinIO server data directories
 minio_server_datadirs:
   - /var/lib/minio

--- a/tasks/install-server.yml
+++ b/tasks/install-server.yml
@@ -17,6 +17,11 @@
   set_fact:
     _minio_server_checksum: "{{ lookup('url', _minio_server_download_url + '.sha256sum').split(' ')[0] }}"
 
+- name: "Append the MinIO console addr to minio_server_opts variable"
+  set_fact:
+    minio_server_opts: "--console-address {{ minio_console_addr }} {{ minio_server_opts }}"
+  when: minio_console_addr | length > 1
+
 - name: Create MinIO group
   group:
     name: "{{ minio_group }}"


### PR DESCRIPTION
Added support to define a static port for the embedded MinIO Console.
Omit to direct MinIO to generate a dynamic port at server startup. The MinIO server outputs the port to the system log.