### PR TITLE
fix: dynamic handler not found in some cases

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,10 +10,10 @@
   service:
     name: minio
     state: restarted
-  notify: Check Minio on '{{ minio_connection_type }}'
+  notify: Check MinIO WebUI
   become: true
 
-- name: Check Minio on '{{ minio_connection_type }}'
+- name: Check MinIO WebUI
   uri:
     url: "{{ minio_connection_type }}://{{ minio_hostname }}:{{ minio_server_port }}/minio/login"
     status_code: 200

--- a/tasks/install-server.yml
+++ b/tasks/install-server.yml
@@ -105,4 +105,4 @@
     enabled: true
     state: started
   become: true
-  notify: Check Minio on '{{ minio_connection_type }}'
+  notify: Check MinIO WebUI


### PR DESCRIPTION
**Issue:**

Not 100% sure of root-cause, but when setting `minio_enable_ssl: true` outside of the context of the role call (we have an external inventory that we call with `ANSIBLE_INVENTORY` environment variable), the following handler fails to execute

```
TASK [minio : Enable and start the MinIO service] *************************************************************************
ERROR! The requested handler 'Check Minio on 'https'' was not found in either the main handlers list nor in the listening handlers list
```

**Proposal**:

Make the `uri` handler task static by removing the `{{ minio_connection_type }}` variable in the name of the task.

tested successfully with `minio_enable_ssl: true` and `minio_enable_ssl: false`

**Environment**

Ansible 2.9.18