### PR TITLE
add simple HTTPS support via minio_server_dns with Let's Encrypt

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,3 +61,4 @@ minio_install_client: true
 
 # TODO: in future
 minio_enable_ssl: false
+minio_certbot_renewal_dir: "/etc/letsencrypt/renewal-hooks/deploy"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,8 +3,7 @@
 
 - name: reload minio systemd
   systemd:
-    name: minio
-    daemon_reload: True
+    daemon_reload: yes
 
 - name: restart minio
   service:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -13,7 +13,7 @@
 
 - name: Check MinIO WebUI
   uri:
-    url: "{{ minio_connection_type }}://{{ minio_hostname }}:{{ minio_server_port }}/minio/login"
+    url: "{{ minio_connection_type }}://{{ minio_server_addr }}/minio/login"
     status_code: 200
     headers:
       User-Agent: "Mozilla/5.0"

--- a/tasks/https.yml
+++ b/tasks/https.yml
@@ -1,0 +1,59 @@
+- name: Generate HTTPS cert via certbot standalone
+  command: >
+    certbot --non-interactive certonly
+    --server https://acme-v02.api.letsencrypt.org/directory
+    --expand
+    -a standalone
+    --email {{ minio_letsencrypt_email }} --agree-tos
+    --cert-name {{ minio_server_dns }}
+    -d {{ minio_server_dns }}
+  args:
+    creates: "/etc/letsencrypt/live/{{ minio_server_dns }}/fullchain.pem"
+  register: minio_letsencrypt_cert_gen
+  when: lookup('community.general.dig', minio_server_dns, qtype='A') == ansible_default_ipv4.address
+
+- name: Stat generated HTTPS cert from certbot
+  stat:
+    path: "/etc/letsencrypt/live/{{ minio_server_dns }}/fullchain.pem"
+  register: minio_letsencrypt_cert_chk
+  changed_when: not minio_letsencrypt_cert_chk.stat.exists
+
+- name: Ensure certs dir in $HOME/.minio
+  file:
+    path: "/home/{{ minio_user }}/.minio/certs"
+    state: directory
+
+- name: Copy latest HTTPS cert and key to $HOME/.minio
+  copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: "{{ minio_user }}"
+    group: "{{ minio_group }}"
+    remote_src: yes
+  loop_control:
+    label: "{{ item.src }}"
+  loop:
+    - src: "/etc/letsencrypt/live/{{ minio_server_dns }}/fullchain.pem"
+      dest: "/home/{{ minio_user }}/.minio/certs/public.crt"
+    - src: "/etc/letsencrypt/live/{{ minio_server_dns }}/privkey.pem"
+      dest: "/home/{{ minio_user }}/.minio/certs/private.key"
+  when: minio_letsencrypt_cert_chk.stat.exists
+
+- name: Renewal hook for certbot to copy cert and key
+  template:
+    src: certbot-renewal-hook_deploy.sh.j2
+    dest: "{{ minio_certbot_renewal_dir }}/minio"
+    mode: "+x"
+  when: minio_letsencrypt_cert_chk.stat.exists
+
+- name: Set addresses to domain and server port 443
+  set_fact:
+    minio_server_addr: "{{ minio_server_dns }}:443"
+    minio_server_port: 443
+    minio_console_addr: "{{ minio_server_dns }}:9001"
+  when: minio_letsencrypt_cert_chk.stat.exists
+
+- name: Append certs-dir to minio_server_opts
+  set_fact:
+    minio_server_opts: "{{ minio_server_opts | default('') + '--certs-dir /home/{{ minio_user }}/.minio/certs' }}"
+  when: minio_letsencrypt_cert_chk.stat.exists

--- a/tasks/install-server.yml
+++ b/tasks/install-server.yml
@@ -59,6 +59,9 @@
   delay: 2
   notify: restart minio
 
+- include_tasks: https.yml
+  when: minio_enable_ssl
+
 - name: Generate the MinIO server envfile
   template:
     src: minio.env.j2

--- a/templates/certbot-renewal-hook_deploy.sh.j2
+++ b/templates/certbot-renewal-hook_deploy.sh.j2
@@ -1,0 +1,9 @@
+#!/bin/sh
+# copy latest HTTPS cert and key to $HOME/.minio
+cp "/etc/letsencrypt/live/{{ minio_server_dns }}/fullchain.pem" \
+  "/home/{{ minio_user }}/.minio/certs/public.crt"
+chown minio:minio "/home/{{ minio_user }}/.minio/certs/public.crt"
+cp "/etc/letsencrypt/live/{{ minio_server_dns }}/privkey.pem" \
+  "/home/{{ minio_user }}/.minio/certs/private.key"
+chown minio:minio "/home/{{ minio_user }}/.minio/certs/private.key"
+/bin/systemctl restart minio


### PR DESCRIPTION
@harshavardhana Cheers from the Ansible community at CfgMmgtCamp 2023 in Ghent, Belgium :waffle:  
`minio_enable_ssl` defaults still to false and certbot is only used if `minio_server_dns` resolves to host.  